### PR TITLE
Fix NSIS filepath limitation

### DIFF
--- a/.github/workflows/headless.yml
+++ b/.github/workflows/headless.yml
@@ -138,33 +138,35 @@ jobs:
       shell: cmd
       run: |
         call "%VCVARS%"
-        mkdir build
-        cd build
+        cd ..
+        mkdir b
+        cd b
         cmake ^
           -DPARAVIEW_USE_QT=OFF ^
           -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
           -DCMAKE_BUILD_TYPE=Release ^
           -GNinja ^
-          ..
+          %GITHUB_WORKSPACE%
 
     - name: Build ParaView
       shell: cmd
       run: |
         call "%VCVARS%"
-        cd build
+        cd ..\b
         cmake --build . --config Release --parallel
 
     - name: Create ParaView package
       shell: bash
       run: |
-        cd build
+        cd ../b
         cpack -G NSIS64
+        mv ttk-paraview.exe $GITHUB_WORKSPACE
 
     - name: Upload install executable
       uses: actions/upload-artifact@v2
       with:
         name: ttk-paraview-headless-windows
-        path: build/ttk-paraview.exe
+        path: ttk-paraview.exe
 
 
   # --------------------- #

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -159,32 +159,34 @@ jobs:
       shell: cmd
       run: |
         call "%VCVARS%"
-        mkdir build
-        cd build
+        cd ..
+        mkdir b
+        cd b
         cmake ^
           -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
           -DCMAKE_BUILD_TYPE=Release ^
           -GNinja ^
-          ..
+          %GITHUB_WORKSPACE%
 
     - name: Build patched ParaView
       shell: cmd
       run: |
         call "%VCVARS%"
-        cd build
+        cd ..\b
         cmake --build . --config Release --parallel
 
     - name: Create package
       shell: bash
       run: |
-        cd build
+        cd ../b
         cpack -G NSIS64
+        mv ttk-paraview.exe $GITHUB_WORKSPACE
 
     - name: Upload .exe installer
       uses: actions/upload-artifact@v2
       with:
         name: ttk-paraview.exe
-        path: build/ttk-paraview.exe
+        path: ttk-paraview.exe
 
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The NSIS packager is used on Windows to create the ttk-paraview installer. With ParaView 5.10, the packaging step hits the [maximum path limitation](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation) (260 characters) when trying to compress the file `VTK/ThirdParty/vtkm/vtkvtkm/vtk-m/vtkm/worklet/contourtree_distributed/boundary_tree_maker/AugmentBoundaryWithNecessaryInteriorSupernodesAppendNecessarySupernodesWorklet.h`.

This PR moves and renames the build directory (where the compressing process happens) in order to shorten the path of the offending file. 

Enjoy,
Pierre