### PR TITLE
[ci-pv513] Fixes for package generation

### DIFF
--- a/.github/workflows/headless.yml
+++ b/.github/workflows/headless.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
     steps:
     - uses: actions/checkout@v4
       name: Checkout TTK-ParaView source code
@@ -103,7 +103,6 @@ jobs:
           $GITHUB_WORKSPACE
 
     - name: Build ParaView
-      continue-on-error: true
       run: |
         cd build
         cmake --build . --parallel
@@ -111,8 +110,6 @@ jobs:
     - name: Create ParaView package
       run: |
         cd build
-        echo -e "===\n\n\nDisplaying vtkPVVersionQuick.h...\n\n\n==="
-        cat Utilities/Versioning/vtkPVVersionQuick.h
         cpack -G TGZ
 
     - name: Upload compressed binaries

--- a/.github/workflows/headless.yml
+++ b/.github/workflows/headless.yml
@@ -232,14 +232,6 @@ jobs:
         file: ttk-paraview-headless-ubuntu-22.04/ttk-paraview.deb
         asset_name: ttk-paraview-headless-ubuntu-22.04.deb
 
-    - name: Upload Ubuntu Noble Numbat .deb as Release Asset
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref }}
-        file: ttk-paraview-headless-ubuntu-24.04/ttk-paraview.deb
-        asset_name: ttk-paraview-headless-ubuntu-24.04.deb
-
     - name: Upload MacOS 14 (arm64) .tar.gz as Release Asset
       uses: svenstaro/upload-release-action@v2
       with:

--- a/Remoting/Core/vtkPVFileInformation.cxx
+++ b/Remoting/Core/vtkPVFileInformation.cxx
@@ -1246,7 +1246,11 @@ std::string vtkPVFileInformation::GetParaViewSharedResourcesDirectory()
 
   // Where docs might be in relation to the executable
   std::vector<std::string> prefixes = {
+#if defined(_WIN32) || defined(__APPLE__)
+    ".."
+#else
     "share/paraview-" PARAVIEW_VERSION
+#endif
   };
 
   // Search for the docs directory

--- a/Remoting/Core/vtkPVFileInformation.cxx
+++ b/Remoting/Core/vtkPVFileInformation.cxx
@@ -1261,11 +1261,6 @@ std::string vtkPVFileInformation::GetParaViewSharedResourcesDirectory()
     resource_dir = vtksys::SystemTools::CollapseFullPath(resource_dir);
   }
 
-  vtkProcessModule* pm = vtkProcessModule::GetProcessModule();
-
-  if((pm)&&(prefixes.size()))
-    resource_dir = pm->GetSelfDir() + "/../" + prefixes[0];
-
   return resource_dir;
 }
 


### PR DESCRIPTION
This PR fixes package generation for ParaView 5.13.0 (both headless and standard).